### PR TITLE
Drop python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
     - 3.3
     - 3.4

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ To use WebSocket Client API, you also need to install `websocket-client <https:/
 Requirements
 ------------
 
-* Python 2.6, 2.7, 3.3, 3.4, 3.5 or 3.6.
+* Python 2.7, 3.3, 3.4, 3.5 or 3.6.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='sensorbee-python',
       classifiers=[
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
It seems that the latest websocket-client v0.48.0 does not work with Python 2.6 anymore.

cc/ @rimms is this change OK for you?